### PR TITLE
.gitignore - ingen *.meta filer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Unity3D Generated File On Crash Reports
 sysinfo.txt
+
+# Ignore all meta files
+*.meta


### PR DESCRIPTION
Det burde være muligt ikke at inkludere .meta-filerne. De bliver alligevel genereret, når man åbner unity, 3d og andet på sin egen computer.
Er der konsekvenser ved at gøre det?
